### PR TITLE
Fix incorrect type on 64b systems

### DIFF
--- a/minizip/zipcrypt.h
+++ b/minizip/zipcrypt.h
@@ -32,7 +32,7 @@
 /***********************************************************************
  * Return the next byte in the pseudo-random sequence
  */
-static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab)
+static int decrypt_byte(z_crc_t* pkeys, const z_crc_t* pcrc_32_tab)
 {
     unsigned temp;  /* POTENTIAL BUG:  temp*(temp^1) may overflow in an
                      * unpredictable manner on 16-bit systems; not a problem
@@ -45,7 +45,7 @@ static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab)
 /***********************************************************************
  * Update the encryption keys with the next byte of plain text
  */
-static int update_keys(unsigned long* pkeys,const unsigned long* pcrc_32_tab,int c)
+static int update_keys(z_crc_t* pkeys,const z_crc_t* pcrc_32_tab,int c)
 {
     (*(pkeys+0)) = CRC32((*(pkeys+0)), c);
     (*(pkeys+1)) += (*(pkeys+0)) & 0xff;
@@ -62,7 +62,7 @@ static int update_keys(unsigned long* pkeys,const unsigned long* pcrc_32_tab,int
  * Initialize the encryption keys and the random header according to
  * the given password.
  */
-static void init_keys(const char* passwd,unsigned long* pkeys,const unsigned long* pcrc_32_tab)
+static void init_keys(const char* passwd,z_crc_t* pkeys,const z_crc_t* pcrc_32_tab)
 {
     *(pkeys+0) = 305419896L;
     *(pkeys+1) = 591751049L;
@@ -90,9 +90,9 @@ static void init_keys(const char* passwd,unsigned long* pkeys,const unsigned lon
 static int crypthead(const char* passwd,      /* password string */
                      unsigned char* buf,      /* where to write header */
                      int bufSize,
-                     unsigned long* pkeys,
-                     const unsigned long* pcrc_32_tab,
-                     unsigned long crcForCrypting)
+                     z_crc_t* pkeys,
+                     const z_crc_t* pcrc_32_tab,
+                     z_crc_t crcForCrypting)
 {
     int n;                       /* index in random header */
     int t;                       /* temporary */

--- a/zip.c
+++ b/zip.c
@@ -156,8 +156,8 @@ typedef struct
     ZPOS64_T totalCompressedData;
     ZPOS64_T totalUncompressedData;
 #ifndef NOCRYPT
-    unsigned long keys[3];     /* keys defining the pseudo-random sequence */
-    const unsigned long* pcrc_32_tab;
+    z_crc_t keys[3];     /* keys defining the pseudo-random sequence */
+    const z_crc_t* pcrc_32_tab;
     int crypt_header_size;
 #endif
 } curfile64_info;


### PR DESCRIPTION
Fix incorrect type used on 64b systems. get_crc_table is returning an array of 32b integers but pcrc_32_tab is declared as a `unsigned long` which is 64b on most 64b systems (except Windows which is LLP64). The compiler (GCC 14 in my case) complains about assignment of different (incompatible) pointer types:

```
domoticz/extern/minizip/zip.c:1248:28: error: assignment to ‘const long unsigned int *’ from incompatible pointer type ‘const z_crc_t *’ {aka ‘const unsigned int *’} [-Wincompatible-pointer-types]
 1248 |         zi->ci.pcrc_32_tab = get_crc_table();
      |                            ^
```