### PR TITLE
Fix markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@ Based on the original work of [Gilles Vollant](http://www.winimage.com/zLibDll/m
 
 ### Usage in a CMake project
 
+```cmake
 add_subdirectory (minizip)
 target_link_libraries(${PROJECT_NAME} minizip)
 INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/minizip)
+```
 
 In your code you can use it like
 
+```c
 #include <minizip/zip.h>
+```
 
 ### Requirement:
 
@@ -18,7 +22,7 @@ In your code you can use it like
 
 ### Usage of library
 
-```
+```c
 #include <minizip/miniunz.h>
 
 unzip(src, dst);


### PR DESCRIPTION
Without this change, the [README](https://github.com/domoticz/minizip/blob/master/README.md) renders:
<img width="738" alt="image" src="https://github.com/user-attachments/assets/ba8af69e-4acc-4098-a893-0b9937eabd98">

With this change, the [README](https://github.com/jsoref/minizip/blob/fix-markdown/README.md) renders:
<img width="851" alt="image" src="https://github.com/user-attachments/assets/110fc8e8-54dd-462f-8c51-bae69c0934df">
